### PR TITLE
Fix Parser Error due missing schema

### DIFF
--- a/backend/mixins/openapi.mixin.js
+++ b/backend/mixins/openapi.mixin.js
@@ -114,9 +114,8 @@ module.exports = function (mixinOptions) {
 					if (process.env.NODE_ENV != "production") {
 						fs.writeFileSync("./openapi.json", JSON.stringify(schema, null, 4), "utf8");
 					}
-
-					return schema;
 				}
+				return schema;
 			}
 		},
 


### PR DESCRIPTION
On the first run, the schema was not returned, generating an error: `"Parser error: end of the stream or a document separator is expected".`
Only after regenerating the schema did the ui work. (i.e: Saving and hot reloading a file).

![image](https://user-images.githubusercontent.com/25640856/168966967-1ebad22f-33bc-4cf1-81c0-3fea36add9f8.png)

